### PR TITLE
add sharks::Share + Cargo.lock update

### DIFF
--- a/enclave/Cargo.lock
+++ b/enclave/Cargo.lock
@@ -351,7 +351,7 @@ checksum = "434e1720189a637d44fe464f4df1e6eb900b4835255b14354497c78af37d9bb8"
 dependencies = [
  "byteorder",
  "digest 0.8.1",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle 2.4.0",
  "zeroize",
 ]
@@ -364,7 +364,7 @@ checksum = "639891fde0dbea823fc3d798a0fdf9d2f9440a42d64a78ab3488b0ca025117b3"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle 2.4.0",
  "zeroize",
 ]
@@ -422,7 +422,7 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek 3.1.0",
  "ed25519",
- "rand",
+ "rand 0.7.3",
  "sha2 0.9.5",
  "zeroize",
 ]
@@ -998,7 +998,7 @@ dependencies = [
  "crunchy",
  "digest 0.8.1",
  "hmac-drbg",
- "rand",
+ "rand 0.7.3",
  "sha2 0.8.2",
  "subtle 2.4.0",
  "typenum",
@@ -1065,7 +1065,7 @@ checksum = "4e261cf0f8b3c42ded9f7d2bb59dea03aa52bc8a1cbc7482f9fc3fd1229d3b42"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core",
+ "rand_core 0.5.1",
  "zeroize",
 ]
 
@@ -1562,8 +1562,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.5.1",
  "rand_hc",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1573,7 +1582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1583,12 +1592,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1730,7 +1745,7 @@ dependencies = [
  "arrayvec 0.5.2",
  "curve25519-dalek 2.1.2",
  "merlin",
- "rand_core",
+ "rand_core 0.5.1",
  "sha2 0.8.2",
  "subtle 2.4.0",
  "zeroize",
@@ -2086,6 +2101,16 @@ dependencies = [
  "digest 0.9.0",
  "keccak",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sharks"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902b1e955f8a2e429fb1bad49f83fb952e6195d3c360ac547ff00fb826388753"
+dependencies = [
+ "hashbrown",
+ "rand 0.8.4",
 ]
 
 [[package]]
@@ -2583,6 +2608,7 @@ dependencies = [
  "sgx_tstd",
  "sgx_tunittest",
  "sgx_types",
+ "sharks",
  "sp-application-crypto",
  "sp-core",
  "sp-finality-grandpa",

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -43,6 +43,7 @@ lazy_static       = { version = "1.1.0", features = ["spin_no_std"] }
 retain_mut        = { version = "0.1.2"}
 derive_more       = { version = "0.99.5" }
 byteorder         = { version = "1.4.2", default-features = false}
+sharks            = { version = "0.5", default-features = false }
 
 
 # for attestation

--- a/enclave/src/keyvault.rs
+++ b/enclave/src/keyvault.rs
@@ -7,6 +7,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::prelude::v1::*;
 use std::vec::Vec;
+use sharks::Share;
 
 pub const STORAGE_PATH: &str = "keyshare";
 


### PR DESCRIPTION
Added sharks library to enclave. I fixed the error by running 
`cargo update -p sgx_tstd --precise ed9e7cce4fd40efd7a256d5c4be1c5f00778a5bb` within the enclave workspace :)

You don't need to merge if you want to do it yourself, but since I did it to check anyway, I created this PR